### PR TITLE
Fixed a bug in RegisterExpectedMemoryLeak

### DIFF
--- a/FastMM4.pas
+++ b/FastMM4.pas
@@ -13846,6 +13846,9 @@ begin
   {Add it to the correct list}
   Result := LockExpectedMemoryLeaksList
     and UpdateExpectedLeakList(@ExpectedMemoryLeaks.FirstEntryByAddress, @LNewEntry);
+{$ifndef AssumeMultiThreaded}
+  if IsMultiThread then
+{$endif}
   ReleaseLockByte(ExpectedMemoryLeaksListLocked);
 end;
 
@@ -13864,6 +13867,9 @@ begin
   {Add it to the correct list}
   Result := LockExpectedMemoryLeaksList
     and UpdateExpectedLeakList(@ExpectedMemoryLeaks.FirstEntryByClass, @LNewEntry);
+{$ifndef AssumeMultiThreaded}
+  if IsMultiThread then
+{$endif}
   ReleaseLockByte(ExpectedMemoryLeaksListLocked);
 end;
 
@@ -13886,6 +13892,9 @@ begin
       {Add it to the correct list}
       Result := LockExpectedMemoryLeaksList
         and UpdateExpectedLeakList(@ExpectedMemoryLeaks.FirstEntryByClass, @LNewEntry);
+      {$ifndef AssumeMultiThreaded}
+        if IsMultiThread then
+      {$endif}
       ReleaseLockByte(@ExpectedMemoryLeaksListLocked);
     end
     else
@@ -13915,6 +13924,9 @@ begin
   {Add it to the correct list}
   Result := LockExpectedMemoryLeaksList
     and UpdateExpectedLeakList(@ExpectedMemoryLeaks.FirstEntryBySizeOnly, @LNewEntry);
+{$ifndef AssumeMultiThreaded}
+  if IsMultiThread then
+{$endif}
   ReleaseLockByte(ExpectedMemoryLeaksListLocked);
 end;
 
@@ -13937,6 +13949,9 @@ begin
   {Remove it from the list}
   Result := LockExpectedMemoryLeaksList
     and UpdateExpectedLeakList(@ExpectedMemoryLeaks.FirstEntryByAddress, @LNewEntry);
+{$ifndef AssumeMultiThreaded}
+  if IsMultiThread then
+{$endif}
   ReleaseLockByte(ExpectedMemoryLeaksListLocked);
 end;
 


### PR DESCRIPTION
Fixed a bug where registering a memory leak in debug mode produced an exception because of an attempt to release a non existing lock. The lock is never set in LockExpectedMemoryLeaksList because IsMultiThreaded is False at the time.