### PR TITLE
Removal of UTF-8 BOM - old versions of Delphi do not support it.

### DIFF
--- a/FastMM4.pas
+++ b/FastMM4.pas
@@ -1,4 +1,4 @@
-﻿(*
+(*
 
 FastMM4-AVX (AVX1/AVX2/AVX512/ERMS support for FastMM4)
 


### PR DESCRIPTION
A minor issue that prevents building on D5.