### PR TITLE
Delphi 5 compatbility fixes when building in full debug mode.

### DIFF
--- a/FastMM4.pas
+++ b/FastMM4.pas
@@ -2283,6 +2283,11 @@ const
 {$endif}
 {$endif}
 
+{$ifdef Delphi4or5}
+ reInvalidOp = 217;
+{$endif}
+
+
 {-------------------------Private types----------------------------}
 type
 
@@ -7223,7 +7228,11 @@ end;
 function NegByteMaskBit(A: Byte): Byte;
 {$ifndef ASMVersion}
 begin
+{$ifdef Delphi4or5}
+  Result := Byte((0-ShortInt(A)));
+{$else}
   Result := Byte((0-System.Int8(A)));
+{$endif}
 end;
 {$else}
 assembler;


### PR DESCRIPTION
Realized it does not build in full debug mode. Suspect there might be some more cases where it does not build, but I do not know the options so well. 

Also not certain which version of Delphi introduced reInvalidOp as well as Int8.