### PR TITLE
Fixed PByte definition for compiler version <20

### DIFF
--- a/FastMM4.pas
+++ b/FastMM4.pas
@@ -1707,7 +1707,7 @@ type
   {Make sure all the required types are available}
 {$ifdef BCB6OrDelphi6AndUp}
   {$if CompilerVersion < 20}
-  PByte = PAnsiChar;
+  PByte = PAnsiChar; {$define PByteIsPAnsiChar}
   {NativeInt didn't exist or was broken before Delphi 2009.}
   NativeInt = Integer;
   {$ifend}


### PR DESCRIPTION
Fixed PByte definition for compiler version <20 (PByteIsPAnsiChar define added).

It will fix line 7282:
`LClassInfoByte1 := {$ifdef PByteIsPAnsiChar}Byte{$endif}(PByte(LClassInfoPByte + 1)^);`
type cast.