### PR TITLE
Fix MediumBlocksLocked not poisoned during finalization

### DIFF
--- a/FastMM4.pas
+++ b/FastMM4.pas
@@ -21136,7 +21136,7 @@ begin
     end;
 
   {$IFDEF MediumBlocksLockedCriticalSection}
-  LargeBlocksLocked := CLockByteFinished;
+  MediumBlocksLocked := CLockByteFinished;
   {$IFDEF fpc}DoneCriticalSection{$ELSE}DeleteCriticalSection{$ENDIF}(MediumBlocksLockedCS);
   {$ENDIF MediumBlocksLockedCriticalSection}
 


### PR DESCRIPTION
## Summary

- Fix copy-paste bug in `FinalizeMemoryManager`: the `{$IFDEF MediumBlocksLockedCriticalSection}` block set `LargeBlocksLocked := CLockByteFinished` instead of `MediumBlocksLocked := CLockByteFinished`
- `MediumBlocksLocked` was never poisoned with the shutdown sentinel, so post-finalization medium block operations were silently missed by `DebugAcquireLockByte`, unlike small and large blocks which were properly guarded
- The wrong variable name has been present since commit 9ebf71f and became active for default builds after commit c89b4ac restructured the ifdef branches

## Test plan

- [ ] Verify Delphi 32-bit and 64-bit Windows builds compile cleanly
- [ ] Verify FPC Linux 64-bit build compiles cleanly
- [ ] Confirm `MediumBlocksLocked` is set to `CLockByteFinished` in finalization (debug inspection or code review)

Relates to #55

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a critical section cleanup issue in memory management that could improve system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->