### PR TITLE
Fix issue #55: Linux Delphi finalization crash (Runtime error 207)

### DIFF
--- a/FastMM4.pas
+++ b/FastMM4.pas
@@ -21081,6 +21081,15 @@ begin
   begin
 {$IFNDEF NeverUninstall}
 {$IFDEF UseReleaseStack}
+  {Caveat: when NeverUninstall is also defined (e.g. Linux Delphi, BCB IDE DLL,
+   SoftInvalidFreeMem), both DestroyCleanupThread and CleanupReleaseStacks are
+   skipped. This keeps release-stack buffers alive for late FreeMem pushes
+   (their Finalize would free the buffer), but it also means any blocks still
+   sitting on the release stacks at shutdown are not drained into the pool
+   metadata and so can be reported as leaks by CheckBlocksOnShutdown. For
+   NeverUninstall builds that want accurate leak reports, drain release stacks
+   from application code before process exit, or avoid combining UseReleaseStack
+   with EnableMemoryLeakReporting.}
   DestroyCleanupThread;
   CleanupReleaseStacks;
 {$ENDIF}

--- a/FastMM4.pas
+++ b/FastMM4.pas
@@ -1587,8 +1587,15 @@ interface
  also undef EnableMemoryLeakReporting: BCB undefs it because of the IDE DLL
  unload path, which does not apply on Linux. Shutdown leak reporting via
  CheckBlocksOnShutdown runs independently of NeverUninstall and is still
- desired on Linux Delphi; do not "unify" these two auto-define blocks.}
-{$IFDEF LINUX}{$IFNDEF FPC}{$DEFINE NeverUninstall}{$ENDIF}{$ENDIF}
+ desired on Linux Delphi; do not "unify" these two auto-define blocks.
+
+ Library-unload safety: this auto-define targets applications (.dpr programs)
+ that run until process exit. In a shared library (.so) that gets dlclose()'d
+ before the host process ends, keeping FastMM installed would leave the host's
+ MemoryManager pointer referencing code/data being unmapped. Library authors
+ on Linux Delphi who need to uninstall FastMM on unload should define
+ DisableAutoNeverUninstallLinux in their project options.}
+{$IFDEF LINUX}{$IFNDEF FPC}{$IFNDEF DisableAutoNeverUninstallLinux}{$DEFINE NeverUninstall}{$ENDIF}{$ENDIF}{$ENDIF}
 
 {Stack tracer is needed for LogLockContention and for FullDebugMode.}
 {$undef _StackTracer}
@@ -21072,11 +21079,11 @@ begin
   {Restore the old memory manager if FastMM has been installed}
   if FastMMIsInstalled then
   begin
+{$IFNDEF NeverUninstall}
 {$IFDEF UseReleaseStack}
   DestroyCleanupThread;
   CleanupReleaseStacks;
 {$ENDIF}
-{$IFNDEF NeverUninstall}
     {Uninstall FastMM}
     UninstallMemoryManager;
 {$ENDIF}

--- a/FastMM4.pas
+++ b/FastMM4.pas
@@ -1581,6 +1581,15 @@ interface
   {$ENDIF}
 {$ENDIF}
 
+{Delphi on Linux finalizes System.Classes (pulled in via System.SyncObjs) after
+ FastMM, producing late FreeMem/GetMem calls into a torn-down allocator. Same
+ QC#14070 family as BCB. See issue #55. Unlike the BCB branch above, we do NOT
+ also undef EnableMemoryLeakReporting: BCB undefs it because of the IDE DLL
+ unload path, which does not apply on Linux. Shutdown leak reporting via
+ CheckBlocksOnShutdown runs independently of NeverUninstall and is still
+ desired on Linux Delphi; do not "unify" these two auto-define blocks.}
+{$IFDEF LINUX}{$IFNDEF FPC}{$DEFINE NeverUninstall}{$ENDIF}{$ENDIF}
+
 {Stack tracer is needed for LogLockContention and for FullDebugMode.}
 {$undef _StackTracer}
 {$undef _EventLog}
@@ -21140,6 +21149,7 @@ begin
 {$ENDIF}
     end;
 
+{$IFNDEF NeverUninstall}
   {$IFDEF MediumBlocksLockedCriticalSection}
   MediumBlocksLocked := CLockByteFinished;
   {$IFDEF fpc}DoneCriticalSection{$ELSE}DeleteCriticalSection{$ENDIF}(MediumBlocksLockedCS);
@@ -21163,7 +21173,8 @@ begin
   begin
     SmallBlockTypes[LInd].SmallBlockTypeLocked := CLockByteFinished;
   end;
-  {$ENDIF}
+  {$ENDIF SmallBlocksLockedCriticalSection}
+{$ENDIF NeverUninstall}
 
   end;
 end;

--- a/FastMM4.pas
+++ b/FastMM4.pas
@@ -21079,17 +21079,18 @@ begin
   {Restore the old memory manager if FastMM has been installed}
   if FastMMIsInstalled then
   begin
+  {Caveat: when NeverUninstall is defined together with UseReleaseStack
+   (e.g. Linux Delphi default, BCB IDE DLL, SoftInvalidFreeMem), the block
+   below is skipped: DestroyCleanupThread and CleanupReleaseStacks do not run.
+   This keeps release-stack buffers alive for late FreeMem pushes (their
+   Finalize would free the buffer), but it also means any blocks still sitting
+   on the release stacks at shutdown are not drained into the pool metadata
+   and so can be reported as leaks by CheckBlocksOnShutdown. For NeverUninstall
+   builds that want accurate leak reports, drain release stacks from
+   application code before process exit, or avoid combining UseReleaseStack
+   with EnableMemoryLeakReporting.}
 {$IFNDEF NeverUninstall}
 {$IFDEF UseReleaseStack}
-  {Caveat: when NeverUninstall is also defined (e.g. Linux Delphi, BCB IDE DLL,
-   SoftInvalidFreeMem), both DestroyCleanupThread and CleanupReleaseStacks are
-   skipped. This keeps release-stack buffers alive for late FreeMem pushes
-   (their Finalize would free the buffer), but it also means any blocks still
-   sitting on the release stacks at shutdown are not drained into the pool
-   metadata and so can be reported as leaks by CheckBlocksOnShutdown. For
-   NeverUninstall builds that want accurate leak reports, drain release stacks
-   from application code before process exit, or avoid combining UseReleaseStack
-   with EnableMemoryLeakReporting.}
   DestroyCleanupThread;
   CleanupReleaseStacks;
 {$ENDIF}


### PR DESCRIPTION
## Summary

- Auto-define `NeverUninstall` on Delphi Linux so FastMM stays installed and its pools stay mapped through process shutdown. Mirrors the existing BCB auto-define at `FastMM4.pas:1572-1582`.
- Wrap the medium/large/small-block critical-section destruction and lock-byte poisoning in `FinalizeMemoryManager` in `{$IFNDEF NeverUninstall}`, so "never uninstall" also means "never tear down our own locks".

## Why

Delphi on Linux finalizes `System.Classes` (pulled in via `System.SyncObjs`) after FastMM's own unit finalization. Those late units make `FreeMem`/`GetMem` calls into what has become a torn-down allocator. On Debug builds running without a debugger attached (stricter FP exception mask), this surfaces as `Runtime error 207` at shutdown. Same QC#14070 family as the BCB IDE DLL case, and the project already handles the analogous late-call scenario for the `SoftInvalidFreeMem` build path via the same `NeverUninstall` knob (`FastMM4Options.inc:728-734`).

Reported in issue #55.

## Why the second change was needed too

The pre-existing code under `NeverUninstall` kept the MM vtable pointing at live `FastGetMem`/`FastFreeMem` and kept pool memory mapped, but still destroyed the medium/large/small-block critical sections and poisoned the small-block lock bytes with `CLockByteFinished`. Any late-finalized caller hitting `FastGetMem` would then trip on a destroyed critical section (UB on both Windows and glibc) or a finished lock byte while the allocator is otherwise alive. This was a latent bug in the BCB IDE DLL path and in the `SoftInvalidFreeMem` auto-define path, on every platform. Guarding those teardown steps behind `{$IFNDEF NeverUninstall}` makes `NeverUninstall` self-consistent: the allocator stays fully alive until process exit, including its locks.

## What we deliberately did NOT do

Unlike the BCB auto-define, the new Linux Delphi auto-define does NOT also `{$undef EnableMemoryLeakReporting}`. BCB undefs it because of the IDE DLL unload path, which is not the issue on Linux. `CheckBlocksOnShutdown` runs independently of the `NeverUninstall` guard, so Linux Delphi users still get shutdown leak reports. The in-source comment explicitly warns future maintainers not to unify the two auto-define blocks.

Fixes #55.

