### PR TITLE
Fix issue #54: silence Linux H2164 and Win32 W1072 compiler hints

### DIFF
--- a/FastMM4.pas
+++ b/FastMM4.pas
@@ -9813,7 +9813,7 @@ begin
           {Is this bin now empty?}
           if LNextFreeBlock = LPMediumBin then
           begin
-            LShift := LBinNumber and (MediumBlockBinsPerGroup-1);
+            LShift := Byte(LBinNumber and (MediumBlockBinsPerGroup-1));
             LMask := not (Cardinal(UnsignedBit) shl LShift);
             {Flag this bin as empty}
             MediumBlockBinBitmaps[LBinGroupNumber] := MediumBlockBinBitmaps[LBinGroupNumber] and LMask;
@@ -10008,7 +10008,7 @@ begin
 
       {Calculate the bin group}
       LBinGroupNumber := LBinNumber shr MediumBlockBinsPerGroupPowerOf2;
-      LShift := LBinNumber and (MediumBlockBinsPerGroup-1);
+      LShift := Byte(LBinNumber and (MediumBlockBinsPerGroup-1));
       {Is there a suitable block inside this group?}
       LBinGroupMasked := MediumBlockBinBitmaps[LBinGroupNumber] and NegCardinalMaskBit(Cardinal(UnsignedBit) shl LShift);
       if LBinGroupMasked <> 0 then
@@ -18228,7 +18228,7 @@ begin
           LPMsg := AppendStringToBuffer(LogStateAllocatedMsg, LPMsg, Length(LogStateAllocatedMsg), Cardinal(LInitialSize-NativeUInt(LPMsg-LPInitialMsgPtr)));
           LPMsg := NativeUIntToStrBuf(LMemoryManagerUsageSummary.OverheadBytes shr 10, LPMsg, Cardinal(LInitialSize-NativeUInt(LPMsg-LPInitialMsgPtr)));
           LPMsg := AppendStringToBuffer(LogStateOverheadMsg, LPMsg, Length(LogStateOverheadMsg), Cardinal(LInitialSize-NativeUInt(LPMsg-LPInitialMsgPtr)));
-          LPMsg := NativeUIntToStrBuf(Round(LMemoryManagerUsageSummary.EfficiencyPercentage), LPMsg, Cardinal(LInitialSize-NativeUInt(LPMsg-LPInitialMsgPtr)));
+          LPMsg := NativeUIntToStrBuf(NativeUInt(Round(LMemoryManagerUsageSummary.EfficiencyPercentage)), LPMsg, Cardinal(LInitialSize-NativeUInt(LPMsg-LPInitialMsgPtr)));
           LPMsg := AppendStringToBuffer(LogStateEfficiencyMsg, LPMsg, Length(LogStateEfficiencyMsg), Cardinal(LInitialSize-NativeUInt(LPMsg-LPInitialMsgPtr)));
           {Log the allocation detail}
           for LInd := LPLogInfo^.NodeCount - 1 downto 0 do
@@ -20035,8 +20035,10 @@ var
   LPSmallBlockPoolHeader: PSmallBlockPoolHeader;
   LPSmallBlockType: PSmallBlockType;
 {$IFDEF Use_GetEnabledXStateFeatures_WindowsAPICall}
+{$IFDEF USE_CPUID}
   FGetEnabledXStateFeatures: TGetEnabledXStateFeatures;
   EnabledXStateFeatures: Int64;
+{$ENDIF}
 {$ENDIF}
 
 {$IFDEF USE_CPUID}
@@ -20571,7 +20573,7 @@ ENDQUOTE}
     for LSizeInd := (LPreviousBlockSize div SmallBlockGranularity) to Cardinal(NativeUInt(SmallBlockTypes[LInd].BlockSize - 1) shr SmallBlockGranularityPowerOf2) do
     begin
    {$IFDEF AllocSize2SmallBlockTypesPrecomputedOffsets}
-      AllocSz2SmlBlkTypOfsDivSclFctr[LSizeInd] := LInd shl (SmallBlockTypeRecSizePowerOf2 - MaximumCpuScaleFactorPowerOf2);
+      AllocSz2SmlBlkTypOfsDivSclFctr[LSizeInd] := Byte(LInd shl (SmallBlockTypeRecSizePowerOf2 - MaximumCpuScaleFactorPowerOf2));
    {$ELSE}
       AllocSize2SmallBlockTypesIdx[LSizeInd] := Byte(LInd);
    {$ENDIF}
@@ -21072,8 +21074,10 @@ end;
 
 procedure FinalizeMemoryManager;
 {$IFDEF SmallBlocksLockedCriticalSection}
+{$IFNDEF NeverUninstall}
 var
   LInd: Integer;
+{$ENDIF}
 {$ENDIF}
 begin
   {Restore the old memory manager if FastMM has been installed}


### PR DESCRIPTION
## Summary

Addresses the second batch of compiler hints reported by @Molochnik in [issue #54 comment](https://github.com/maximmasiutin/FastMM4-AVX/issues/54#issuecomment-4267126509). The prior 64-bit round is clean; this PR clears the Linux H2164 (declared-but-never-used) and Win32 W1072 (implicit-conversion) diagnostics.

Group 1 H2077 dead-store hints on the small and medium block free paths were deliberately left unchanged: those assignments are safeguards that keep locals well-defined when conditional-compilation branches drop the reader, and silencing them by tightening ifdef guards would couple the initializer to readers the authors want to keep decoupled.

## Changes

Group 2 (Linux H2164 unused variable):

- `FastMM4.pas:20037` `FGetEnabledXStateFeatures`, `EnabledXStateFeatures` declaration guard changed from `{$IFDEF Use_GetEnabledXStateFeatures_WindowsAPICall}` to also require `USE_CPUID`. All readers live inside the `{$IFDEF USE_CPUID}` block starting at line 20104, so on Linux PurePascal builds (where PurePascal turns USE_CPUID off) the declarations now drop out cleanly.
- `FastMM4.pas:21074` `LInd` in `FinalizeMemoryManager` declaration guard changed from `{$IFDEF SmallBlocksLockedCriticalSection}` to also require `not Defined(NeverUninstall)`. All readers are inside `{$IFNDEF NeverUninstall}` at lines 21169-21194, so Linux builds that enable NeverUninstall (default on Delphi Linux per PR #58) no longer see a dangling declaration.

Group 3 (Win32 W1072 implicit conversion):

- `FastMM4.pas:9816`, `FastMM4.pas:10011` wrap `LBinNumber and (MediumBlockBinsPerGroup-1)` in `Byte(...)`. Expression range is 0..31.
- `FastMM4.pas:18231` wrap `Round(LMemoryManagerUsageSummary.EfficiencyPercentage)` in `NativeUInt(...)`. `Round` returns Int64; the efficiency percentage is 0..100 so the explicit narrowing is safe. Fixes the one real 32-bit truncation diagnostic.
- `FastMM4.pas:20574` wrap `LInd shl (SmallBlockTypeRecSizePowerOf2 - MaximumCpuScaleFactorPowerOf2)` in `Byte(...)`. Target array element type is `Byte`; the shifted index is bounded at compile time.

No behavioral change on any configuration; this is a diagnostics-only cleanup.

## Test plan

- [ ] Delphi Linux x64 build: confirm the three H2164 entries (lines 20038, 20039, 21076 in the comment) are gone.
- [ ] Delphi Win32 build: confirm the four W1072 entries (lines 9816, 10011, 18231, 20574) are gone.
- [ ] Delphi Win64 build: confirm no new hints or warnings appear; the prior 64-bit round stays clean.
- [ ] Run `Tests/Simple`, `Tests/Benchmark`, and `Tests/Replacement BorlndMM DLL` on Win32 and Win64 to catch any regression from the added `Byte(...)` casts around bit operations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal memory manager optimizations and type handling adjustments for improved compile-time configuration flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->