### PR TITLE
Fix FreeMem: validate medium block size before ClearSmallAndMedium FillChar

### DIFF
--- a/FastMM4.pas
+++ b/FastMM4.pas
@@ -12197,13 +12197,36 @@ begin
     {Is this a medium block or a large block?}
     if (LBlockHeader and (IsFreeBlockFlag or IsLargeBlockFlag)) = 0 then
     begin
-{$IFDEF ClearSmallAndMediumBlocksInFreeMem}
-      {Get the block header, extract the block size and clear the block it.}
+      {Guard: validate medium block size BEFORE the ClearSmallAndMedium
+       FillChar call. A foreign pointer (not allocated by FastMM) can have
+       a garbage header whose masked size either underflows below
+       BlockHeaderSize or exceeds the pool, causing FillChar to zero
+       arbitrary memory. FreeMediumBlock still carries a redundant check
+       for defense-in-depth. Issue #39.}
       LBlockHeader := PNativeUInt(PByte(APointer) - BlockHeaderSize)^;
-      FillChar(APointer^,
-        (LBlockHeader and DropMediumAndLargeFlagsMask) - BlockHeaderSize, 0);
+      if ((LBlockHeader and DropMediumAndLargeFlagsMask) < MinimumMediumBlockSize) or
+         ((LBlockHeader and DropMediumAndLargeFlagsMask) > (MediumBlockPoolSize - MediumBlockPoolHeaderSize)) then
+      begin
+{$IFDEF SoftInvalidFreeMem}
+        Result := 0;
+{$ELSE}
+  {$IFDEF BCB6OrDelphi7AndUp}
+        System.Error(reInvalidPtr);
+  {$ELSE}
+        System.RunError(reInvalidPtr);
+  {$ENDIF}
+        Result := CFastFreeMemReturnValueError;
 {$ENDIF}
-      Result := FreeMediumBlock(APointer);
+      end
+      else
+      begin
+{$IFDEF ClearSmallAndMediumBlocksInFreeMem}
+        {Block size now validated; safe to clear before freeing.}
+        FillChar(APointer^,
+          (LBlockHeader and DropMediumAndLargeFlagsMask) - BlockHeaderSize, 0);
+{$ENDIF}
+        Result := FreeMediumBlock(APointer);
+      end;
     end
     else
     begin
@@ -12566,17 +12589,11 @@ By default, it will not be compiled into FastMM4-AVX which uses more efficient a
   jnz @NotASmallOrMediumBlock
   {$IFDEF AsmCodeAlign}{$IFDEF AsmAlNodot}align{$ELSE}.align{$ENDIF} 4{$ENDIF}
 @FreeMediumBlock:
-{$IFDEF ClearSmallAndMediumBlocksInFreeMem}
-  push eax
-  push edx
-  and edx, DropMediumAndLargeFlagsMask
-  sub edx, BlockHeaderSize
-  xor ecx, ecx
-  call System.@FillChar
-  pop edx
-  pop eax
-{$ENDIF}
-  {Drop the flags}
+  {Drop the flags BEFORE any FillChar so size validation runs first.
+   Moving the size check ahead of ClearSmallAndMediumBlocksInFreeMem
+   prevents a foreign-pointer header with a garbage masked size from
+   driving FillChar into unrelated memory or an unsigned underflow.
+   Issue #39.}
   and edx, DropMediumAndLargeFlagsMask
   {Validate block size: must be between MinimumMediumBlockSize and the
    maximum usable pool space. A foreign pointer (not allocated by FastMM)
@@ -12594,7 +12611,18 @@ By default, it will not be compiled into FastMM4-AVX which uses more efficient a
 {$ELSE}
   ja @CorruptMediumBlockSize
 {$ENDIF}
-  {Free the medium block pointed to by eax, header in edx}
+{$IFDEF ClearSmallAndMediumBlocksInFreeMem}
+  {Size now validated: safe to clear. edx holds size without flags;
+   FillChar takes size - BlockHeaderSize.}
+  push eax
+  push edx
+  sub edx, BlockHeaderSize
+  xor ecx, ecx
+  call System.@FillChar
+  pop edx
+  pop eax
+{$ENDIF}
+  {Free the medium block pointed to by eax, header (size without flags) in edx}
   {Block size in ebx}
   mov ebx, edx
   {Save registers}
@@ -13234,16 +13262,11 @@ By default, it will not be compiled into FastMM4-AVX which uses more efficient a
   jnz @NotASmallOrMediumBlock
   {$IFDEF AsmCodeAlign}{$IFDEF AsmAlNodot}align{$ELSE}.align{$ENDIF} 8{$ENDIF}
 @FreeMediumBlock:
-{$IFDEF ClearSmallAndMediumBlocksInFreeMem}
-  mov rsi, rcx
-  and rdx, DropMediumAndLargeFlagsMask
-  sub rdx, BlockHeaderSize
-  xor r8, r8
-  call System.@FillChar
-  mov rcx, rsi
-  mov rdx, [rcx - BlockHeaderSize]
-{$ENDIF}
-  {Drop the flags}
+  {Drop the flags BEFORE any FillChar so size validation runs first.
+   Moving the size check ahead of ClearSmallAndMediumBlocksInFreeMem
+   prevents a foreign-pointer header with a garbage masked size from
+   driving FillChar into unrelated memory or an unsigned underflow.
+   Issue #39.}
   and rdx, DropMediumAndLargeFlagsMask
   {Validate block size: must be between MinimumMediumBlockSize and the
    maximum usable pool space. A foreign pointer (not allocated by FastMM)
@@ -13261,7 +13284,18 @@ By default, it will not be compiled into FastMM4-AVX which uses more efficient a
 {$ELSE}
   ja @CorruptMediumBlockSize
 {$ENDIF}
-  {Free the medium block pointed to by eax, header in edx}
+{$IFDEF ClearSmallAndMediumBlocksInFreeMem}
+  {Size validated; safe to clear. rsi preserves APointer across the call
+   because FillChar destroys volatile regs (rcx, rdx, r8-r11).}
+  mov rsi, rcx
+  sub rdx, BlockHeaderSize
+  xor r8, r8
+  call System.@FillChar
+  mov rcx, rsi
+  mov rdx, [rcx - BlockHeaderSize]
+  and rdx, DropMediumAndLargeFlagsMask
+{$ENDIF}
+  {Free the medium block pointed to by rcx, size (without flags) in rdx}
   {Block size in rbx}
   mov rbx, rdx
   {Pointer in rsi}

--- a/FastMM4.pas
+++ b/FastMM4.pas
@@ -11908,6 +11908,9 @@ var
   LPSmallBlockType: PSmallBlockType;
   LOldFirstFreeBlock: Pointer;
   LBlockHeader: NativeUInt;
+{$IFDEF ClearSmallAndMediumBlocksInFreeMem}
+  LBlockSize: NativeUInt;
+{$ENDIF}
 {$IFDEF LogLockContention}
   LDidSleep: Boolean;
   LStackTrace: TStackTrace;
@@ -12197,36 +12200,40 @@ begin
     {Is this a medium block or a large block?}
     if (LBlockHeader and (IsFreeBlockFlag or IsLargeBlockFlag)) = 0 then
     begin
+{$IFDEF ClearSmallAndMediumBlocksInFreeMem}
       {Guard: validate medium block size BEFORE the ClearSmallAndMedium
        FillChar call. A foreign pointer (not allocated by FastMM) can have
        a garbage header whose masked size either underflows below
        BlockHeaderSize or exceeds the pool, causing FillChar to zero
-       arbitrary memory. FreeMediumBlock still carries a redundant check
-       for defense-in-depth. Issue #39.}
+       arbitrary memory. When clearing is disabled this extra pre-check is
+       skipped because FreeMediumBlock's internal bounds check runs before
+       the block dereferences its neighbours and suffices on its own.
+       Issue #39.}
       LBlockHeader := PNativeUInt(PByte(APointer) - BlockHeaderSize)^;
-      if ((LBlockHeader and DropMediumAndLargeFlagsMask) < MinimumMediumBlockSize) or
-         ((LBlockHeader and DropMediumAndLargeFlagsMask) > (MediumBlockPoolSize - MediumBlockPoolHeaderSize)) then
+      LBlockSize := LBlockHeader and DropMediumAndLargeFlagsMask;
+      if (LBlockSize < MinimumMediumBlockSize) or
+         (LBlockSize > (MediumBlockPoolSize - MediumBlockPoolHeaderSize)) then
       begin
-{$IFDEF SoftInvalidFreeMem}
+  {$IFDEF SoftInvalidFreeMem}
         Result := 0;
-{$ELSE}
-  {$IFDEF BCB6OrDelphi7AndUp}
-        System.Error(reInvalidPtr);
   {$ELSE}
+    {$IFDEF BCB6OrDelphi7AndUp}
+        System.Error(reInvalidPtr);
+    {$ELSE}
         System.RunError(reInvalidPtr);
-  {$ENDIF}
+    {$ENDIF}
         Result := CFastFreeMemReturnValueError;
-{$ENDIF}
+  {$ENDIF}
       end
       else
       begin
-{$IFDEF ClearSmallAndMediumBlocksInFreeMem}
-        {Block size now validated; safe to clear before freeing.}
-        FillChar(APointer^,
-          (LBlockHeader and DropMediumAndLargeFlagsMask) - BlockHeaderSize, 0);
-{$ENDIF}
+        {Block size validated; safe to clear before freeing.}
+        FillChar(APointer^, LBlockSize - BlockHeaderSize, 0);
         Result := FreeMediumBlock(APointer);
       end;
+{$ELSE}
+      Result := FreeMediumBlock(APointer);
+{$ENDIF}
     end
     else
     begin


### PR DESCRIPTION
## Summary

Finding 5 of the 2026-04-17 security review: in FastFreeMem, the `ClearSmallAndMediumBlocksInFreeMem` path called `FillChar` with a size derived from the raw block header before `FreeMediumBlock` validated it. A foreign pointer whose low 3 bits encode `IsMediumBlockFlag` but whose upper bits are garbage can produce two attack shapes:

- Oversized size (e.g. `$00100002`): `FillChar(P, ~1 MiB, 0)` zeros unrelated memory or hits a guard page.
- Undersized size (below `BlockHeaderSize`): unsigned underflow yields a near-`High(NativeUInt)` length; `FillChar` runs until it hits an unmapped page.

This fix moves the `MinimumMediumBlockSize` / `MediumBlockPoolSize - MediumBlockPoolHeaderSize` range check ahead of the `FillChar` call in:

- Pascal `FastFreeMem` medium-block branch.
- 32-bit ASM `@FreeMediumBlock`.
- 64-bit ASM `@FreeMediumBlock`.

`FreeMediumBlock` retains its own bounds check as defense-in-depth. Under `SoftInvalidFreeMem` the failure path returns 0; otherwise it raises `reInvalidPtr` via `System.Error` or `System.RunError`.

Related: issue #39 (foreign-pointer tolerance), PR plan file `SECURITY_FIX_PR_PLAN.md` (PR-SEC-02 in fastmm4-avx-reports).

