### PR TITLE
Fix ASM FreeMem: validate SmallBlockType before ClearSmallAndMedium FillChar

### DIFF
--- a/FastMM4.pas
+++ b/FastMM4.pas
@@ -12352,18 +12352,12 @@ for flags like IsMultiThreaded or MediumBlocksLocked}
   cmp edx, $10000
   jb @InvalidSmallBlock
 {$ENDIF}
-{$IFDEF ClearSmallAndMediumBlocksInFreeMem}
-  push edx
-  push ecx
-  mov edx, TSmallBlockPoolHeader[edx].BlockType
-  movzx edx, TSmallBlockType(edx).BlockSize
-  sub edx, BlockHeaderSize
-  xor ecx, ecx
-  call System.@FillChar
-  pop ecx
-  pop edx
-{$ENDIF}
-  {Get the small block type in ebx}
+  {Load BlockType ONCE from the pool header into ebx (callee-saved)
+   BEFORE the ClearSmallAndMediumBlocksInFreeMem FillChar so the bounds
+   and alignment check below can run before any dereference of BlockType.
+   Without this ordering, a foreign pointer with a mapped-but-garbage pool
+   pointer would let FillChar read garbage BlockType.BlockSize and zero
+   an attacker-influenced length. Issue #39.}
   mov ebx, TSmallBlockPoolHeader[edx].BlockType
 {$IFDEF SoftInvalidFreeMem}
   {Validate that BlockType points within the SmallBlockTypes array and is
@@ -12381,6 +12375,18 @@ for flags like IsMultiThreaded or MediumBlocksLocked}
   add eax, ebx
   test eax, (SmallBlockTypeRecSize - 1)
   jnz @InvalidSmallBlock
+{$ENDIF}
+{$IFDEF ClearSmallAndMediumBlocksInFreeMem}
+  {BlockType validated; safe to read BlockSize and clear the user region.
+   ebx holds the validated BlockType across the call (callee-saved in x86).}
+  push edx
+  push ecx
+  movzx edx, TSmallBlockType(ebx).BlockSize
+  sub edx, BlockHeaderSize
+  xor ecx, ecx
+  call System.@FillChar
+  pop ecx
+  pop edx
 {$ENDIF}
   {Do we need to lock the block type?}
 {$IFNDEF AssumeMultiThreaded}
@@ -12958,17 +12964,12 @@ asm
   cmp rdx, $10000
   jb @InvalidSmallBlock
 {$ENDIF}
-{$IFDEF ClearSmallAndMediumBlocksInFreeMem}
-  mov rsi, rcx
-  mov rdx, TSmallBlockPoolHeader[rdx].BlockType
-  movzx edx, TSmallBlockType(rdx).BlockSize
-  sub edx, BlockHeaderSize
-  xor r8, r8
-  call System.@FillChar
-  mov rcx, rsi
-  mov rdx, [rcx - BlockHeaderSize]
-{$ENDIF}
-  {Get the small block type in rbx}
+  {Load BlockType ONCE from the pool header into rbx (callee-saved)
+   BEFORE the ClearSmallAndMediumBlocksInFreeMem FillChar so the bounds
+   and alignment check below can run before any dereference of BlockType.
+   Without this ordering, a foreign pointer with a mapped-but-garbage pool
+   pointer would let FillChar read garbage BlockType.BlockSize and zero
+   an attacker-influenced length. Issue #39.}
   mov rbx, TSmallBlockPoolHeader[rdx].BlockType
 {$IFDEF SoftInvalidFreeMem}
   {Validate that BlockType points within the SmallBlockTypes array and is
@@ -12986,6 +12987,18 @@ asm
   add rax, rbx
   test rax, (SmallBlockTypeRecSize - 1)
   jnz @InvalidSmallBlock
+{$ENDIF}
+{$IFDEF ClearSmallAndMediumBlocksInFreeMem}
+  {BlockType validated; safe to read BlockSize and clear the user region.
+   rsi preserves APointer across the call; rbx is callee-saved so it
+   survives FillChar without explicit save.}
+  mov rsi, rcx
+  movzx edx, TSmallBlockType(rbx).BlockSize
+  sub edx, BlockHeaderSize
+  xor r8, r8
+  call System.@FillChar
+  mov rcx, rsi
+  mov rdx, [rcx - BlockHeaderSize]
 {$ENDIF}
   {Do we need to lock the block type?}
 {$IFNDEF AssumeMultiThreaded}

--- a/FastMM4.pas
+++ b/FastMM4.pas
@@ -12378,9 +12378,13 @@ for flags like IsMultiThreaded or MediumBlocksLocked}
 {$ENDIF}
 {$IFDEF ClearSmallAndMediumBlocksInFreeMem}
   {BlockType validated; safe to read BlockSize and clear the user region.
-   ebx holds the validated BlockType across the call (callee-saved in x86).}
+   ebx holds the validated BlockType across the call (callee-saved in x86).
+   EAX was clobbered by the SmallBlockTypes range/alignment check (lea/neg
+   etc.) so restore it from ECX (APointer) before the FillChar register
+   convention (EAX=Dest, EDX=Count, CL=Value).}
   push edx
   push ecx
+  mov eax, ecx
   movzx edx, TSmallBlockType(ebx).BlockSize
   sub edx, BlockHeaderSize
   xor ecx, ecx


### PR DESCRIPTION
## Summary

Finding 4 of the 2026-04-17 security review. In the ASM `FastFreeMem` small-block branch, PR #44 moved the pool pointer guard (`cmp rdx, \$10000`) ahead of `ClearSmallAndMediumBlocksInFreeMem`, but the companion `SmallBlockType` bounds-and-alignment check stayed after the `FillChar` call. A foreign pointer whose header is above 64 KiB (passing the pool guard) but still garbage could let `FillChar` read `TSmallBlockType.BlockSize` from an attacker-influenced address, giving a write-what-where-but-zero primitive with attacker-controlled length.

Changes, symmetrically applied to 32-bit and 64-bit ASM:

1. Load `BlockType` once from the pool header into `ebx`/`rbx` (callee-saved).
2. Run the `SmallBlockTypes` range and `SmallBlockTypeRecSize` alignment check on `ebx`/`rbx` before any dereference.
3. Inside the `ClearSmallAndMediumBlocksInFreeMem` block, read `TSmallBlockType(ebx/rbx).BlockSize` using the validated register; drop the duplicate `mov ebx/rbx, TSmallBlockPoolHeader[...].BlockType` that previously followed the clear block.

The Pascal path already had this ordering; this brings the ASM paths into alignment.

Related: issue #39, PR #44 (partial fix), PR #60 (medium-block analogue).

## Test plan

- [ ] `SoftInvalidFreeMemTest`, `SimpleTest`, `AdvancedTest` must pass on 32-bit and 64-bit builds.
- [ ] Benchmark suite throughput within 2% of master (extra load/cmp/lea/test run on every small-block FreeMem).
- [ ] Manual exploit-shape vector under `SoftInvalidFreeMem + AlwaysClearFreedMemory`: header = address of a HeapAlloc block Q where `[Q + BlockType_offset]` is garbage. Current master zeros an attacker-influenced length; with this PR the SmallBlockType bounds check rejects before FillChar.