### PR TITLE
Fix ASM FreeMem: large-block foreign-pointer guards (size, granularity, page-align)

### DIFF
--- a/FastMM4.pas
+++ b/FastMM4.pas
@@ -12856,7 +12856,7 @@ By default, it will not be compiled into FastMM4-AVX which uses more efficient a
   jnz @DontFreeLargeBlock
   {Large-block foreign pointer guard: size non-zero, aligned to
    LargeBlockGranularity, base page-aligned. Mirrors the Pascal path
-   guard at FastMM4.pas:12213-12232. Without this, FreeLargeBlock would
+   guard at FastMM4.pas:12260-12268. Without this, FreeLargeBlock would
    read the large-block linked-list header from an attacker-influenced
    address and call VirtualFree on a non-VirtualAlloc pointer.
    ecx holds a copy of APointer, no longer live here, so use it as a
@@ -13549,7 +13549,7 @@ but we don't need them at this point}
   jnz @DoubleFreeDetected
   {Large-block foreign pointer guard: size non-zero, aligned to
    LargeBlockGranularity, base page-aligned. Mirrors the Pascal path
-   guard at FastMM4.pas:12213-12232. Without this, FreeLargeBlock would
+   guard at FastMM4.pas:12260-12268. Without this, FreeLargeBlock would
    read the large-block linked-list header from an attacker-influenced
    address and call VirtualFree on a non-VirtualAlloc pointer. rax is
    volatile in Win64 ABI so it can be used as scratch without save.

--- a/FastMM4.pas
+++ b/FastMM4.pas
@@ -12854,6 +12854,24 @@ By default, it will not be compiled into FastMM4-AVX which uses more efficient a
   {Is it in fact a large block?}
   test dl, IsFreeBlockFlag + IsMediumBlockFlag
   jnz @DontFreeLargeBlock
+  {Large-block foreign pointer guard: size non-zero, aligned to
+   LargeBlockGranularity, base page-aligned. Mirrors the Pascal path
+   guard at FastMM4.pas:12213-12232. Without this, FreeLargeBlock would
+   read the large-block linked-list header from an attacker-influenced
+   address and call VirtualFree on a non-VirtualAlloc pointer.
+   ecx holds a copy of APointer, no longer live here, so use it as a
+   scratch. On failure, jmp @DontFreeLargeBlock which maps to
+   xor eax, eax in SoftInvalidFreeMem and reInvalidPtr otherwise.
+   Issue #39.}
+  mov ecx, edx
+  and ecx, DropMediumAndLargeFlagsMask
+  jz @DontFreeLargeBlock
+  test ecx, LargeBlockGranularity - 1
+  jnz @DontFreeLargeBlock
+  mov ecx, eax
+  sub ecx, LargeBlockHeaderSize
+  test ecx, MinimumPageSizeMask
+  jnz @DontFreeLargeBlock
   pop ebx
 {$IFNDEF AssumeMultiThreaded}
   pop ebp
@@ -13528,6 +13546,23 @@ but we don't need them at this point}
 @NotASmallOrMediumBlock:
   {Is it in fact a large block?}
   test dl, IsFreeBlockFlag + IsMediumBlockFlag
+  jnz @DoubleFreeDetected
+  {Large-block foreign pointer guard: size non-zero, aligned to
+   LargeBlockGranularity, base page-aligned. Mirrors the Pascal path
+   guard at FastMM4.pas:12213-12232. Without this, FreeLargeBlock would
+   read the large-block linked-list header from an attacker-influenced
+   address and call VirtualFree on a non-VirtualAlloc pointer. rax is
+   volatile in Win64 ABI so it can be used as scratch without save.
+   On failure, jmp @DoubleFreeDetected (xor eax, eax in Soft mode,
+   reInvalidPtr otherwise). Issue #39.}
+  mov rax, rdx
+  and rax, DropMediumAndLargeFlagsMask
+  jz @DoubleFreeDetected
+  test rax, LargeBlockGranularity - 1
+  jnz @DoubleFreeDetected
+  mov rax, rcx
+  sub rax, LargeBlockHeaderSize
+  test rax, MinimumPageSizeMask
   jnz @DoubleFreeDetected
   call FreeLargeBlock
   jmp @Done


### PR DESCRIPTION
## Summary

Finding 3 of the 2026-04-17 security review. PR #50 hardened the Pascal `FastFreeMem` large-block branch with a three-part foreign-pointer guard: (1) size non-zero, (2) size aligned to `LargeBlockGranularity` (64 KiB), (3) base pointer page-aligned. The 32-bit and 64-bit ASM paths at `@NotASmallOrMediumBlock` fell through directly to `call FreeLargeBlock` without any guard.

Attack shape: a foreign pointer whose header byte is `IsLargeBlockFlag` (value 4 mod 8) reaches ASM `FastFreeMem`. `FreeLargeBlock` then reads `PreviousLargeBlockHeader`/`NextLargeBlockHeader` from `P - LargeBlockHeaderSize` (unvalidated) and calls `VirtualFree` on a non-`VirtualAlloc` address.

Port the Pascal guard to both ASM paths:

- 32-bit: use `ecx` as scratch (no longer live at that point); failure jumps to `@DontFreeLargeBlock`.
- 64-bit: use `rax` (volatile per Win64 ABI, so no save needed); failure jumps to `@DoubleFreeDetected`.

Both failure labels already distinguish `SoftInvalidFreeMem` mode (`xor eax, eax`, return 0) from hard mode (raise `reInvalidPtr` via `System.Error` or `System.RunError`). No new labels or control-flow structures needed.

Related: issue #39, PR #50 (Pascal path), PR #60 (PR-SEC-02, medium-block FillChar ordering), PR #61 (PR-SEC-01, SmallBlockType guard ordering).

## Test plan

- [ ] Existing test suite (`SoftInvalidFreeMemTest`, `SimpleTest`, `AdvancedTest`) passes on 32-bit and 64-bit builds.
- [ ] Exploit-shape vector under `SoftInvalidFreeMem`: header `\$04` on a `HeapAlloc` block must now return 0 instead of reaching `VirtualFree`.
- [ ] Exploit-shape vector without `SoftInvalidFreeMem`: same input must raise `reInvalidPtr`.
- [ ] Valid large-block allocation/free loop (`GetMem(512 * 1024)` x 100) must complete with no leak.