### PR TITLE
Add medium-block size validation to ASM FastReallocMem

### DIFF
--- a/FastMM4.pas
+++ b/FastMM4.pas
@@ -14374,6 +14374,19 @@ asm // FastReallocMemAssembler begin 32-bit
   mov ebx, ecx
   {Drop the flags from the header}
   and ecx, DropMediumAndLargeFlagsMask
+{$IFDEF SoftInvalidFreeMem}
+  {Medium-block size validation: mirrors Pascal FastReallocMem check at
+   FastMM4.pas:13830-13844. Without this, a foreign pointer whose header
+   encodes IsMediumBlockFlag with garbage upper bits lets the lea below
+   compute an attacker-controlled next-block pointer, which subsequent
+   code dereferences to read flags and sometimes write through its
+   NextFreeBlock/PreviousFreeBlock fields (unsafe-unlink primitive).
+   Issue #39.}
+  cmp ecx, MinimumMediumBlockSize
+  jb @InvalidMediumReallocPtr
+  cmp ecx, MediumBlockPoolSize - MediumBlockPoolHeaderSize
+  ja @InvalidMediumReallocPtr
+{$ENDIF}
   {Save edi}
   push edi
   {Get a pointer to the next block in edi}
@@ -14794,6 +14807,14 @@ asm // FastReallocMemAssembler begin 32-bit
    Return nil via the standard 2-register epilogue. Issue #39.}
   xor eax, eax
   jmp @Exit2Reg
+  {$IFDEF AsmCodeAlign}{$IFDEF AsmAlNoDot}align{$ELSE}.align{$ENDIF} 4{$ENDIF}
+@InvalidMediumReallocPtr:
+  {Foreign pointer detected in ASM FastReallocMem medium-block path
+   (size below MinimumMediumBlockSize or above the pool usable space).
+   Stack at this point has only ebx/esi + local var pushed (edi is saved
+   later), so the 2-register epilogue is correct. Issue #39.}
+  xor eax, eax
+  jmp @Exit2Reg
 {$ENDIF}
 
 {Don't need alignment here since all instructions are just one-byte}
@@ -15023,6 +15044,19 @@ asm
   mov rbx, rcx
   {Drop the flags from the header}
   and ecx, DropMediumAndLargeFlagsMask
+{$IFDEF SoftInvalidFreeMem}
+  {Medium-block size validation: mirrors Pascal FastReallocMem check at
+   FastMM4.pas:13830-13844. Without this, a foreign pointer whose header
+   encodes IsMediumBlockFlag with garbage upper bits lets the lea below
+   compute an attacker-controlled next-block pointer, which subsequent
+   code dereferences to read flags and sometimes write through its
+   NextFreeBlock/PreviousFreeBlock fields (unsafe-unlink primitive).
+   Issue #39.}
+  cmp ecx, MinimumMediumBlockSize
+  jb @InvalidMediumReallocPtr
+  cmp ecx, MediumBlockPoolSize - MediumBlockPoolHeaderSize
+  ja @InvalidMediumReallocPtr
+{$ENDIF}
   {Get a pointer to the next block in rdi}
   lea rdi, [rsi + rcx]
   {Subtract the block header size from the old available size}
@@ -15433,6 +15467,13 @@ so ew save RCX and RDX}
 @InvalidSmallReallocPtr:
   {Foreign pointer detected in ASM FastReallocMem small-block path
    (pool pointer below 64 KiB or BlockType outside SmallBlockTypes).
+   Return nil via @Done. Issue #39.}
+  xor eax, eax
+  jmp @Done
+  {$IFDEF AsmCodeAlign}{$IFDEF AsmAlNoDot}align{$ELSE}.align{$ENDIF} 4{$ENDIF}
+@InvalidMediumReallocPtr:
+  {Foreign pointer detected in ASM FastReallocMem medium-block path
+   (size below MinimumMediumBlockSize or above the pool usable space).
    Return nil via @Done. Issue #39.}
   xor eax, eax
   jmp @Done

--- a/FastMM4.pas
+++ b/FastMM4.pas
@@ -14376,7 +14376,7 @@ asm // FastReallocMemAssembler begin 32-bit
   and ecx, DropMediumAndLargeFlagsMask
 {$IFDEF SoftInvalidFreeMem}
   {Medium-block size validation: mirrors Pascal FastReallocMem check at
-   FastMM4.pas:13830-13844. Without this, a foreign pointer whose header
+   FastMM4.pas:13924-13940. Without this, a foreign pointer whose header
    encodes IsMediumBlockFlag with garbage upper bits lets the lea below
    compute an attacker-controlled next-block pointer, which subsequent
    code dereferences to read flags and sometimes write through its
@@ -15046,7 +15046,7 @@ asm
   and ecx, DropMediumAndLargeFlagsMask
 {$IFDEF SoftInvalidFreeMem}
   {Medium-block size validation: mirrors Pascal FastReallocMem check at
-   FastMM4.pas:13830-13844. Without this, a foreign pointer whose header
+   FastMM4.pas:13924-13940. Without this, a foreign pointer whose header
    encodes IsMediumBlockFlag with garbage upper bits lets the lea below
    compute an attacker-controlled next-block pointer, which subsequent
    code dereferences to read flags and sometimes write through its


### PR DESCRIPTION
## Summary

Finding 2 of the 2026-04-17 security review. The 32-bit and 64-bit ASM paths of `FastReallocMem` entered the medium-block branch with no validation of the masked size. A foreign pointer whose header encodes `IsMediumBlockFlag` with garbage upper bits let `lea edi/rdi, [eax/rsi + ecx/rcx]` compute an attacker-controlled next-block pointer. The subsequent code reads `[next-8]` to decide whether the next block is free and may call `RemoveMediumFreeBlock`, dereferencing attacker-chosen `NextFreeBlock`/`PreviousFreeBlock` values (unsafe-unlink primitive).

Changes:

- 32-bit ASM `@NotASmallBlock` medium path: after `and ecx, DropMediumAndLargeFlagsMask`, add `cmp ecx, MinimumMediumBlockSize` and `cmp ecx, MediumBlockPoolSize - MediumBlockPoolHeaderSize`. Failure jumps to new `@InvalidMediumReallocPtr` label which returns nil via `@Exit2Reg`.
- 64-bit ASM equivalent with new 64-bit `@InvalidMediumReallocPtr` label returning nil via `@Done`.
- Mirrors Pascal `FastReallocMem` guard at `FastMM4.pas:13830-13844`.

Guards wrapped in `{$IFDEF SoftInvalidFreeMem}`, consistent with PR #63 (small-block ReallocMem guards) and existing FastFreeMem ASM convention.

Related: issue #39, PR #60 (PR-SEC-02), PR #61 (PR-SEC-01), PR #62 (PR-SEC-03), PR #63 (PR-SEC-04). This completes the 5-PR issue-39 ASM hardening series per SECURITY_FIX_PR_PLAN.md.

## Test plan

- [ ] `SoftInvalidFreeMemTest`, `SimpleTest`, `AdvancedTest` pass on 32-bit and 64-bit.
- [ ] Regression: valid medium-block reallocs (downsize to small, downsize in place, upsize to medium, upsize to large) behave unchanged.
- [ ] Exploit-shape vector under `SoftInvalidFreeMem`: header `\$10000002` on a guarded 8 KiB region must return nil without AV on a 256 MiB wild next-block read.
- [ ] Undersized header `\$00000042` (masked size 64) must return nil before the `lea` computes a bogus next-block pointer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced memory reallocation validation to properly detect and handle invalid pointer scenarios, returning nil instead of proceeding with invalid operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->